### PR TITLE
Remove -t arg to docker run

### DIFF
--- a/bin/phptt-test.sh
+++ b/bin/phptt-test.sh
@@ -18,7 +18,7 @@ function parseTestArgs()
 
 function executeTestSuite()
 {
-    docker run --rm -i -t phptestfestbrasil/phptt:${_TEST_VERSION} make test;
+    docker run --rm -i phptestfestbrasil/phptt:${_TEST_VERSION} make test;
     exit 0;
 }
 
@@ -35,7 +35,7 @@ function singleTest()
 {
     mkdir -p ${_TEST_FILE_DIR}/${_TEST_VERSION}/;
     cp -r ${_TEST_FILE_PATH} ${_TEST_FILE_DIR}/${_TEST_VERSION}/;
-    docker run --rm -i -t \
+    docker run --rm -i \
         -v ${_TEST_FILE_DIR}/${_TEST_VERSION}/:/usr/src/phpt/ \
         phptestfestbrasil/phptt:${_TEST_VERSION} \
         make test TESTS=/usr/src/phpt/${_TEST_FILENAME} \


### PR DESCRIPTION
Remove the "-t" from the docker run command:
https://stackoverflow.com/questions/40536778/how-to-workaround-the-input-device-is-not-a-tty-when-using-grunt-shell-to-invo
The "-t" tells docker to configure the tty, which won't work if you don't have a tty and try to attach to the container (default when you don't do a "-d").