### PR TITLE
Remove "-t" arg  from the docker run command

### DIFF
--- a/bin/phptt-generate.sh
+++ b/bin/phptt-generate.sh
@@ -32,6 +32,6 @@ function executeGenerate()
 {
     parseGenerateArgs ${_COMMAND_ARGS};
     fixGenerateDir;
-    docker run --rm -i -t -w /usr/src/phpt -v ${_GENERATE_DIR}:/usr/src/phpt phptestfestbrasil/phptt:${_GENERATE_VERSION} \
+    docker run --rm -i -w /usr/src/phpt -v ${_GENERATE_DIR}:/usr/src/phpt phptestfestbrasil/phptt:${_GENERATE_VERSION} \
         php /usr/src/php/scripts/dev/generate-phpt.phar ${_GENERATE_ARGS} | sed "s/php generate-phpt.php /phptt/";
 }


### PR DESCRIPTION
Remove "-t" arg  from the docker run command:
https://stackoverflow.com/questions/40536778/how-to-workaround-the-input-device-is-not-a-tty-when-using-grunt-shell-to-invo
The "-t" tells docker to configure the tty, which won't work if you don't have a tty and try to attach to the container (default when you don't do a "-d").